### PR TITLE
Lower matrix dot fix

### DIFF
--- a/src/pyqplib/lower_mat.py
+++ b/src/pyqplib/lower_mat.py
@@ -40,7 +40,6 @@ class LowerMatrix:
 
         for row, col, val in zip(subdiag_rows, subdiag_cols, subdiag_vals):
             p[row] += val * x[col]
-            p[col] += val * x[row]
 
         diag_vals = self.diag_vals
         diag_rows = self.diag_rows

--- a/src/pyqplib/reader.py
+++ b/src/pyqplib/reader.py
@@ -318,15 +318,13 @@ def open_file(filename):
 
     path, extension = os.path.splitext(filename)
 
-    if extension == ".qplib":
-        return open(filename, "r")
 
-    elif extension == ".zip":
+    if extension == ".zip":
         basename = os.path.basename(path)
         return zipfile.Path(filename, at=basename).open("r")
 
-    raise ValueError(f"Unknown extension {extension}")
-
+    return open(filename, "r")
+    
 
 def _read_from(filename, read_problem):
     logger.info(f"Reading QPLIB instance from {filename}")


### PR DESCRIPTION
Fix for `LowerMatrix.dot` function as it does not give a proper result for QPLIB provided solutions.
The way it is handled atm is equivalent to 1/2 $x^\top (Q + Q^\top) x$ instead of 1/2 $x^\top Q x$ as shown [here](https://qplib.zib.de/doc.html).

Note with this fix, `Problem.eval` function returns the correct result when [QPLIB instances](https://qplib.zib.de/instances.html) solution is used for x.

I have also removed the ".qplib" extension check in file reading, as the qplib format is just a text file and should not be forced to have the qplib extension to be valid, imo.

I thank you for this package and your time